### PR TITLE
Migrate to JDK14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:10.0.2-jre-slim
+FROM openjdk:14
 COPY target/*.jar .
 COPY version .
 CMD /usr/bin/java -Xmx400m -Xms400m -jar *.jar 

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,15 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>14</java.version>
+		<maven.compiler.source>14</maven.compiler.source>
+		<maven.compiler.target>14</maven.compiler.target>
+	</properties>
+	
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -11,10 +20,6 @@
 	</parent>
 
 	<artifactId>microservice-kubernetes-demo-order</artifactId>
-
-	<properties>
-		<java.version>1.8</java.version>
-	</properties>
 
 	<build>
 		<plugins>
@@ -26,7 +31,11 @@
 	</build>
 	
 	<dependencies>
-
+		<dependency>
+		    <groupId>org.javassist</groupId>
+		    <artifactId>javassist</artifactId>
+		    <version>3.25.0-GA</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ logging.level.org.springframework.boot.actuate.trace.WebRequestTraceFilter: TRAC
 spring.application.name=order
 server.port=8080
 logging.level.com.ewolff.microservice.order.clients: TRACE
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.initialize=true


### PR DESCRIPTION
I intentionally didn't change the files `.classpath` and `settings/org.eclipse.jdk.core.prefs`. These files are usually generated by Eclipse when importing a Maven project. It's bad practice to keep these files under version control, so I'd recommend to remove them completely from GitHub.